### PR TITLE
Add follow-up date tracking for job prospects

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -38,6 +38,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       interestLevel: "Medium",
       notes: "",
       targetSalary: null,
+      followUpDate: null,
     },
   });
 
@@ -121,6 +122,28 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
                   onChange={(e) => {
                     const val = e.target.value;
                     field.onChange(val === "" ? null : Number(val));
+                  }}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="followUpDate"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Follow-Up Date (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="date"
+                  data-testid="input-follow-up-date"
+                  value={field.value ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === "" ? null : val);
                   }}
                 />
               </FormControl>

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -43,6 +43,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       notes: prospect.notes ?? "",
       targetSalary: prospect.targetSalary ?? null,
+      followUpDate: prospect.followUpDate ?? null,
     },
   });
 
@@ -125,6 +126,28 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
                   onChange={(e) => {
                     const val = e.target.value;
                     field.onChange(val === "" ? null : Number(val));
+                  }}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="followUpDate"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Follow-Up Date (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="date"
+                  data-testid="input-edit-follow-up-date"
+                  value={field.value ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === "" ? null : val);
                   }}
                 />
               </FormControl>

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign, CalendarClock, AlertTriangle } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -39,6 +39,40 @@ function InterestIndicator({ level }: { level: string }) {
     default:
       return null;
   }
+}
+
+function FollowUpReminder({ dateStr }: { dateStr: string }) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const followUp = new Date(dateStr + "T00:00:00");
+
+  const diffDays = Math.floor((followUp.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays < 0) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium text-red-600 dark:text-red-400" data-testid="follow-up-overdue">
+        <AlertTriangle className="w-3 h-3" />
+        Follow-up overdue
+      </span>
+    );
+  }
+
+  if (diffDays === 0) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-600 dark:text-amber-400" data-testid="follow-up-today">
+        <CalendarClock className="w-3 h-3" />
+        Follow up today
+      </span>
+    );
+  }
+
+  const formatted = followUp.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  return (
+    <span className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 dark:text-blue-400" data-testid="follow-up-future">
+      <CalendarClock className="w-3 h-3" />
+      Follow up {formatted}
+    </span>
+  );
 }
 
 export function ProspectCard({ prospect }: { prospect: Prospect }) {
@@ -110,6 +144,9 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
               <DollarSign className="w-3 h-3" />
               {prospect.targetSalary.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 0, maximumFractionDigits: 0 })}
             </span>
+          )}
+          {prospect.followUpDate && (
+            <FollowUpReminder dateStr={prospect.followUpDate} />
           )}
         </div>
 

--- a/replit.md
+++ b/replit.md
@@ -30,11 +30,12 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, target_salary (nullable integer), created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, target_salary (nullable integer), follow_up_date (nullable text YYYY-MM-DD), created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low
 - **Target salary**: Optional integer stored as raw number, formatted as USD currency on the card
+- **Follow-up date**: Optional date stored as YYYY-MM-DD text; card shows "Follow up today" (amber), "Follow-up overdue" (red), or formatted future date (blue)
 
 ## API
 

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -99,3 +99,70 @@ describe("target salary validation", () => {
     expect(result.errors).toContain("Salary must be a positive integer");
   });
 });
+
+describe("follow-up date validation", () => {
+  test("accepts a valid YYYY-MM-DD date", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      followUpDate: "2025-06-15",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts null follow-up date (optional)", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      followUpDate: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts undefined follow-up date (not provided)", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects an invalid date format", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      followUpDate: "06/15/2025",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Follow-up date must be in YYYY-MM-DD format");
+  });
+
+  test("rejects a non-string follow-up date", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      followUpDate: 20250615,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Follow-up date must be in YYYY-MM-DD format");
+  });
+
+  test("rejects a partial date string", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      followUpDate: "2025-06",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Follow-up date must be in YYYY-MM-DD format");
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -46,6 +46,12 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.followUpDate !== undefined && data.followUpDate !== null) {
+    if (typeof data.followUpDate !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(data.followUpDate)) {
+      errors.push("Follow-up date must be in YYYY-MM-DD format");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -51,6 +51,17 @@ export async function registerRoutes(
       }
     }
 
+    if (body.followUpDate !== undefined) {
+      if (body.followUpDate === null || body.followUpDate === "") {
+        updates.followUpDate = null;
+      } else {
+        if (typeof body.followUpDate !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(body.followUpDate)) {
+          return res.status(400).json({ message: "Follow-up date must be in YYYY-MM-DD format" });
+        }
+        updates.followUpDate = body.followUpDate;
+      }
+    }
+
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {
         return res.status(400).json({ message: `Status must be one of: ${STATUSES.join(", ")}` });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -23,6 +23,7 @@ export const prospects = pgTable("prospects", {
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
   targetSalary: integer("target_salary"),
+  followUpDate: text("follow_up_date"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -37,6 +38,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
   targetSalary: z.number().int().positive("Salary must be a positive number").optional().nullable(),
+  followUpDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Follow-up date must be in YYYY-MM-DD format").optional().nullable(),
 });
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;


### PR DESCRIPTION
Adds a new optional `followUpDate` field to job prospects, enabling users to set and track follow-up reminders. This includes UI elements for input and display on prospect cards, backend validation and storage, and corresponding unit tests.